### PR TITLE
Add possibility to override controller's resolver

### DIFF
--- a/lib/boot/controllers.js
+++ b/lib/boot/controllers.js
@@ -18,13 +18,14 @@ module.exports = function(options) {
     options = { dirname: options };
   }
   options = options || {};
-  var dirname = options.dirname || 'app/controllers';
-  
+  var dirname = options.dirname || 'app/controllers',
+      resolver = options.resolver || require('../resolvers/node/controller');
+
   return function controllers() {
     // Register controller resolution and instantiation mechanisms.  These
     // mechanisms allow Maglev to automatically `require` controllers and
     // instantiate instances from the exported value.
-    this.controllers.resolve.use(require('../resolvers/node/controller')(dirname));
+    this.controllers.resolve.use(resolver(dirname));
     this.controllers.instantiate.use(require('../instantiators/di/factory')());
     this.controllers.instantiate.use(require('../instantiators/di/constructor')());
     this.controllers.instantiate.use(require('../instantiators/prototype')());


### PR DESCRIPTION
This PR introduces the possibility to customize controller's auto-discovery as showcased [in this module](https://github.com/viadeo/limbo-controllers-resolver). E.g.:

``` javascript
app
  // default maglev conventions
  .phase(maglev.boot.controllers())
  // or
  // custom auto-discovery conventions
  .phase(maglev.boot.controllers({
    resolver: customControllersResolver
  }))
  ...
  .boot(function (err) { ... })
;
```
